### PR TITLE
fixing access to IPInfo struct from outside which is necessary

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -3,10 +3,11 @@ package ipscanner
 import (
 	"context"
 	"crypto/tls"
-	"github.com/bepass-org/ipscanner/internal/engine"
-	"github.com/bepass-org/ipscanner/internal/statute"
 	"net"
 	"time"
+
+	"github.com/bepass-org/ipscanner/internal/engine"
+	"github.com/bepass-org/ipscanner/internal/statute"
 )
 
 type IPScanner struct {
@@ -241,3 +242,5 @@ func (i *IPScanner) Run() {
 	i.engine = engine.NewScannerEngine(&i.options, context.Background())
 	i.engine.Run()
 }
+
+type IPInfo = statute.IPInfo


### PR DESCRIPTION
In order to define a custom IPQueueChangeCallback we need to access to IPInfo type but since it is defined inside internal directory
we can't access it and thefore we cannot satisfy the 
```go
type TIPQueueChangeCallback func(ips []IPInfo)
```
definiton so I created a reference to IPInfo in scanner.go file in ipscanner package like so 
```go
type IPInfo = statute.IPInfo
```
now we can make our custom callback function like so :
```go
func CustomIPQueueChangeCallback(ips []ipscanner.IPInfo) {
	fmt.Printf("queue change: %d\r\n", len(ips))

}
```